### PR TITLE
Animate header

### DIFF
--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -28,6 +28,8 @@ html {
 }
 
 body {
+	overscroll-behavior: none;
+
 	font-family: var(--body-font-family);
 	font-optical-sizing: var(--body-font-optical-sizing);
 	font-weight: var(--body-font-weight);

--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -22,6 +22,10 @@
 	--image-filter: sepia(20%) grayscale(20%) contrast(90%) brightness(110%)
 }
 
+* {
+	box-sizing: border-box;
+}
+
 html {
 	background-color: rgb(var(--colour-white));
 	color: rgb(var(--colour-black));

--- a/src/lib/header.svelte
+++ b/src/lib/header.svelte
@@ -12,27 +12,160 @@
 
 <style>
     header {
-        position: relative;
-        height: 80vh;
-        padding: 2em;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        padding: 1rem 1.5rem;
+        background-color: rgb(var(--colour-accent));
+
+        animation-name: shrink;
+    }
+
+    @media (prefers-reduced-motion) {
+        header {
+            animation-name: unset;
+            height: 7rem;
+        }
+    }
+
+    header,
+    header::before,
+    header > div > :global(:first-child),
+    header > div > :last-child {
+        animation-fill-mode: both;
+        animation-delay: 0.5s;
+        animation-duration: 5s;
+        animation-timing-function: ease-in-out;
     }
 
     header::before {
         content: "";
+
         position: absolute;
         top: 0;
         left: 0;
         bottom: 0;
         right: 0;
+
         background-image: var(--background-image-src);
         background-size: cover;
+        background-position: bottom;
         filter: var(--image-filter);
+
+        animation-name: fade-out;
+    }
+
+    @media (prefers-reduced-motion) {
+        header::before {
+            animation-name: unset;
+            opacity: 0;
+        }
     }
 
     header > div {
         position: relative;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
+        display: block;
+    }
+
+    header > div > :global(:first-child),
+    header > div > :last-child {
+        position: fixed;
+    }
+
+    header > div > :global(:first-child) {
+        animation-name: move-logo-to-position;
+    }
+
+    @media (prefers-reduced-motion) {
+        header > div > :global(:first-child) {
+            animation-name: unset;
+            top: 1rem;
+            left: 1.5rem;
+            transform: translate(0, 0);
+        }
+    }
+
+    header > div > :last-child {
+        animation-name: move-tagline-to-position;
+    }
+
+    @media (prefers-reduced-motion) {
+        header > div > :last-child {
+            animation-name: unset;
+            top: calc(7rem / 2);
+            right: 1.5rem;
+            transform: translate(0, -50%);
+        }
+    }
+
+    @supports (animation-timeline: scroll()) and (animation-range: cover) {
+        header {
+            top: calc(-95vh + 7rem);
+            animation-play-state: paused;
+        }
+
+        @media (prefers-reduced-motion) {
+            header {
+                top: 0;
+            }
+        }
+
+        header::before,
+        header > div > :global(:first-child),
+        header > div > :last-child {
+            animation-delay: unset;
+            animation-duration: unset;
+            animation-timeline: scroll();
+            animation-range: 0 calc(95vh - 7rem);
+            animation-timing-function: linear;
+        }
+    }
+
+    @keyframes shrink {
+        from {
+            height: 95vh;
+        }
+
+        to {
+            height: 7rem;
+        }
+    }
+
+    @keyframes fade-out {
+        from {
+            opacity: 1;
+        }
+
+        to {
+            opacity: 0;
+        }
+    }
+
+    @keyframes move-logo-to-position {
+        from {
+            top: 47.5vh;
+            left: 50%;
+            transform: translate(-50%, -50%);
+        }
+
+        to {
+            top: 1rem;
+            left: 1.5rem;
+            transform: translate(0, 0);
+        }
+    }
+
+    @keyframes move-tagline-to-position {
+        from {
+            top: calc(47.5vh + 7rem / 2 - 1rem + 1rem);
+            right: 50%;
+            transform: translate(50%, -50%);
+        }
+
+        to {
+            top: calc(7rem / 2);
+            right: 1.5rem;
+            transform: translate(0, -50%);
+        }
     }
 </style>

--- a/src/lib/header.svelte
+++ b/src/lib/header.svelte
@@ -6,7 +6,7 @@
 <header style="--background-image-src: url({meadowGrass});">
     <div>
         <Logo />
-        <span>Affordable low impact gardening</span>
+        <div><span>Affordable low impact gardening</span></div>
     </div>
 </header>
 
@@ -33,8 +33,8 @@
     header > div > :global(:first-child),
     header > div > :last-child {
         animation-fill-mode: both;
-        animation-delay: 0.5s;
-        animation-duration: 5s;
+        animation-delay: 5s;
+        animation-duration: 2s;
         animation-timing-function: ease-in-out;
     }
 
@@ -97,6 +97,21 @@
             transform: translate(0, -50%);
         }
     }
+    
+    header > div > :last-child > span {
+        animation-name: fade-in;
+        animation-fill-mode: both;
+        animation-delay: 3s;
+        animation-duration: 2.5s;
+        animation-timing-function: ease-in-out;
+    }
+
+    @media (prefers-reduced-motion) {
+        header > div > :last-child > span {
+            animation-name: unset;
+            opacity: 1;
+        }
+    }
 
     @supports (animation-timeline: scroll()) and (animation-range: cover) {
         header {
@@ -128,6 +143,16 @@
 
         to {
             height: 7rem;
+        }
+    }
+
+    @keyframes fade-in {
+        from {
+            opacity: 0;
+        }
+
+        to {
+            opacity: 1;
         }
     }
 

--- a/src/lib/logo.svelte
+++ b/src/lib/logo.svelte
@@ -6,6 +6,7 @@
 
 <style>
     h1 {
+        margin-block: 0;
         line-height: 1;
         font-size: 2.5rem;
         display: flex;

--- a/src/lib/logo.svelte
+++ b/src/lib/logo.svelte
@@ -14,15 +14,71 @@
 
     h1 > :nth-child(1) {
         margin-block-start: 0.1em;
+
+        animation-name: fade-in;
+    }
+
+    @media (prefers-reduced-motion) {
+        h1 > :nth-child(1) {
+            animation-name: unset;
+            opacity: 1;
+        }
     }
 
     h1 > :nth-child(2) {
         font-size: 2em;
+
+        animation-name: shrink;
+    }
+
+    @media (prefers-reduced-motion) {
+        h1 > :nth-child(2) {
+            animation-name: unset;
+            transform: scale(1);
+        }
     }
 
     h1 > :nth-child(3) {
         align-self: flex-end;
         margin-inline-start: 0.1em;
         margin-block-end: 0.1em;
+
+        animation-name: fade-in;
+    }
+
+    @media (prefers-reduced-motion) {
+        h1 > :nth-child(3) {
+            animation-name: unset;
+            opacity: 1;
+        }
+    }
+
+    h1 > :nth-child(1),
+    h1 > :nth-child(2),
+    h1 > :nth-child(3) {
+        animation-fill-mode: both;
+        animation-delay: 0.5s;
+        animation-duration: 3s;
+        animation-timing-function: ease-in-out;
+    }
+
+    @keyframes shrink {
+        from {
+            transform: scale(1.5);
+        }
+
+        to {
+            transform: scale(1);
+        }
+    }
+
+    @keyframes fade-in {
+        from {
+            opacity: 0;
+        }
+
+        to {
+            opacity: 1;
+        }
     }
 </style>


### PR DESCRIPTION
Building on #1, this PR adds animation to the header.

We use CSS scroll-based animation if supported, falling back to an auto-playing animation if not.

If the browser is set to prefer reduced motion, we skip to the end.

Start state:

![image](https://github.com/user-attachments/assets/b8b10d6b-41f6-48fb-b72c-c583e82e12ce)

End state:

![image](https://github.com/user-attachments/assets/67b337ca-7b11-4f01-812b-f6ae72ff7441)
