### PR TITLE
Use Lexend for logo ampersand font

### DIFF
--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -19,6 +19,16 @@
 	--heading-font-style: normal;
 	--heading-line-height: 1.5;
 
+	--logo-text-font-family: "Roboto", sans-serif;
+	--logo-text-font-weight: 400;
+	--logo-text-font-optical-sizing: auto;
+	--logo-text-font-style: normal;
+
+	--logo-amp-font-family: "Lexend", sans-serif;
+	--logo-amp-font-weight: 600;
+	--logo-amp-font-optical-sizing: auto;
+	--logo-amp-font-style: normal;
+
 	--image-filter: sepia(20%) grayscale(20%) contrast(90%) brightness(110%);
 }
 

--- a/src/lib/logo.svelte
+++ b/src/lib/logo.svelte
@@ -7,6 +7,10 @@
 <style>
     h1 {
         margin-block: 0;
+        font-family: var(--logo-text-font-family);
+        font-optical-sizing: var(--logo-text-font-optical-sizing);
+        font-weight: var(--logo-text-font-weight);
+        font-style: var(--logo-text-font-style);
         line-height: 1;
         font-size: 2.5rem;
         display: flex;
@@ -26,6 +30,10 @@
     }
 
     h1 > :nth-child(2) {
+        font-family: var(--logo-amp-font-family);
+        font-optical-sizing: var(--logo-amp-font-optical-sizing);
+        font-weight: var(--logo-amp-font-weight);
+        font-style: var(--logo-amp-font-style);
         font-size: 2em;
 
         animation-name: shrink;


### PR DESCRIPTION
The `&` looks better in that font, and it's still used for the body text.

This is another option for #6 (see https://github.com/beeLorna/greenandwild.garden/pull/6#issuecomment-2564757482).