### PR TITLE
Turn carbon badge off

### DIFF
--- a/src/lib/footer.svelte
+++ b/src/lib/footer.svelte
@@ -7,12 +7,6 @@
 		</ul>
 		<p>Copyright © 2025 Green and Wild. All Rights Reserved</p>
 	</div>
-
-	<div id="wcb" class="carbonbadge"></div>
-	<script
-		src="https://unpkg.com/website-carbon-badges@1.1.3/b.min.js"
-		defer
-	></script>
 </footer>
 
 <style>


### PR DESCRIPTION
This is just temporary whilst I sort out the contact form. I don't want to advertise that my website has a high carbon rating. Add this back in once my rating is good.